### PR TITLE
Bump level

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 GITLAB_API_ENDPOINT='http://web/api/v4'
-GITLAB_API_PRIVATE_TOKEN='_PpJe9TiqXNMgAsjGjKi'
+GITLAB_API_PRIVATE_TOKEN='k2VB2ucgDXks6rYF6eRo'
 R10K_REPO_URL="git@web:devops/control-repo.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
+ * Adds the ability to release-mod to dump a specific SemVer release level
+ 
 ## 0.5.3
+
  * Fixes output when applying patch
+
 ## 0.5.2
+
  * Adds proper error handling when missing git author name and email with r10k-deploy
+
 ## 0.5.1
  * Fixes missing error object when credentials are not present
  * Fixes error when deploy-r10k is used and remote setting was not set

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Summary: Bumps the module version to the next revision and
 
     -d, --dry-run                    Do a dry run, without making changes
     -a, --auto                       Run this script without interaction
+    -l, --level			     Semantic versioning level to bump (major.minor.patch), defaults to patch
     -m, --module-path                The path to the module, defaults to current working directory
     -b, --no-bump                    Do not bump the version in metadata.json
     -r, --repo [REPO]                The repo to use, defaults to repo found in the metadata source

--- a/lib/release_manager/cli/release_mod_cli.rb
+++ b/lib/release_manager/cli/release_mod_cli.rb
@@ -25,10 +25,10 @@ module ReleaseManager
         opts.version = ReleaseManager::VERSION
         opts.on_head(<<-EOF
 
-Summary: Bumps the module version to the next revision and 
+Summary: Bumps the module version to the next revision and
          updates the changelog.md file with the new
          version by reading the metadata.json file. This should
-         be run inside a module directory. 
+         be run inside a module directory.
 
         EOF
         )
@@ -36,7 +36,10 @@ Summary: Bumps the module version to the next revision and
           options[:dry_run] = c
         end
         opts.on('-a', '--auto', 'Run this script without interaction') do |c|
-          options[:auto] = c
+          options[:auto] = c 
+        end
+        opts.on('-l', '--level [LEVEL]', 'Semantic versioning level to bump (major,minor,patch), defaults to patch') do |c|
+          options[:level] = c 
         end
         opts.on('-m', '--module-path [MODULEPATH]', "The path to the module, defaults to #{Dir.getwd}") do |c|
           options[:path] = c
@@ -54,6 +57,13 @@ Summary: Bumps the module version to the next revision and
           options[:remote] = true
         end
       end.parse!
+     
+      # validate -l, --level input
+      unless %w(major minor patch).include?(options[:level])
+        puts "expected major minor or patch for parameter -l,  --level. You supplied #{options[:level]}.".fatal
+        exit 1
+      end
+
       r = options[:remote] ?
           RemoteRelease.new(options[:path], options) : Release.new(options[:path], options)
       r.run

--- a/test_release.sh
+++ b/test_release.sh
@@ -1,3 +1,3 @@
-puts `rm -rf ~/repos`
-puts `bundle exec sandbox-create -n box12323 -m apache`
-bundle exec release-mod -m ~/repos/apache/`
+# puts `rm -rf ~/repos`
+# puts `bundle exec sandbox-create -n box12323 -m apache`
+bundle exec release-mod -d -m ~/repos/nationalit-tomcat/`


### PR DESCRIPTION
I added the ability to select the SemVer release level by adding the --level option.  One of my goals during implementation was to perverse the existing interface so that the code is backwards compatible with existing code.  The level option defaults to patch release so the program should behave exactly as it did before with no level option.  Please review and provide feedback.  Thanks